### PR TITLE
Performs no-op when no text is selected

### DIFF
--- a/lua/csgithub/init.lua
+++ b/lua/csgithub/init.lua
@@ -13,6 +13,9 @@ M.search = function(args)
 
 	local query = require("csgithub.query")
 	local q = query.construct_query(merged_args)
+	if q == nil then
+		return nil
+	end
 	local url = query.construct_url(q)
 
 	return url

--- a/lua/csgithub/query.lua
+++ b/lua/csgithub/query.lua
@@ -1,5 +1,12 @@
 local M = {}
 
+--- useful for visual line mode when extra whitespace is 
+--- included in search query
+--- @param s string
+local function trim_string(s)
+   return (s:gsub("^%s*(.-)%s*$", "%1"))
+end
+
 M.construct_query_path = function(args)
 	local ext = vim.fn.expand("%:e")
 
@@ -27,14 +34,14 @@ end
 M.construct_query_text = function()
 	local utils = require("csgithub.utils")
 	local text = ""
-	if vim.fn.mode() == "v" then
-		-- visual mode
-		text = utils.get_visual_selection()
+	local mode = vim.api.nvim_get_mode().mode
+	if mode == "v" or mode == "V" then
+		-- visual mode, visual line mode
+		text = trim_string(utils.get_visual_selection())
 	else
 		-- normal mode
 		text = vim.fn.expand("<cword>")
 	end
-
 	return text
 end
 

--- a/lua/csgithub/query.lua
+++ b/lua/csgithub/query.lua
@@ -50,6 +50,10 @@ end
 M.construct_query = function(args)
 	local query_parts = {}
 
+	local query_text = M.construct_query_text()
+	if query_text == "" then
+		return nil
+	end
 	-- path:
 	if args.includeFilename or args.includeExtension then
 		local path = M.construct_query_path(args)
@@ -58,7 +62,7 @@ M.construct_query = function(args)
 	end
 
 	-- text
-	table.insert(query_parts, M.construct_query_text())
+	table.insert(query_parts, query_text)
 
 	return table.concat(query_parts, " ")
 end

--- a/lua/csgithub/query.lua
+++ b/lua/csgithub/query.lua
@@ -1,12 +1,5 @@
 local M = {}
 
---- useful for visual line mode when extra whitespace is 
---- included in search query
---- @param s string
-local function trim_string(s)
-   return (s:gsub("^%s*(.-)%s*$", "%1"))
-end
-
 M.construct_query_path = function(args)
 	local ext = vim.fn.expand("%:e")
 
@@ -34,14 +27,14 @@ end
 M.construct_query_text = function()
 	local utils = require("csgithub.utils")
 	local text = ""
-	local mode = vim.api.nvim_get_mode().mode
-	if mode == "v" or mode == "V" then
-		-- visual mode, visual line mode
-		text = trim_string(utils.get_visual_selection())
+	if vim.fn.mode() == "v" then
+		-- visual mode
+		text = utils.get_visual_selection()
 	else
 		-- normal mode
 		text = vim.fn.expand("<cword>")
 	end
+
 	return text
 end
 


### PR DESCRIPTION
Before, when no text was selected, github was still searched when calling `search` and `open`. This commit instead performs a no-op when paired with this keymap: 

`local search_github = function ()`
`    local csgithub = require("csgithub")`
`    local url = csgithub.search({`
`	includeFilename=false,`
`	includeExtension=true,`
 `   })`
 `   if url == nil then`
`    	return`
`    end`
`    csgithub.open(url)`
`end`